### PR TITLE
Added DevOps Build to Azure Function

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,6 +26,11 @@ steps:
     msbuildArgs: '/p:DeployOnBuild=true /p:DeployDefaultTarget=WebPublish /p:WebPublishMethod=FileSystem /p:DeleteExistingFiles=True /p:publishUrl="$(Agent.TempDirectory)\WebAppContent\\"'
     platform: '$(BuildPlatform)'
     configuration: '$(BuildConfiguration)'
+- task: ArchiveFiles@2
+  displayName: 'Archive Files'
+  inputs:
+    rootFolderOrFile: '$(Agent.TempDirectory)\WebAppContent'
+    includeRootFolder: false
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact'
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,16 +1,23 @@
 # ASP.NET Core build
-
-pool:
-  vmImage: 'Ubuntu 16.04'
+queue:
+  name: Hosted VS2017
+  demands: 
+  - msbuild
+  - visualstudio
 variables:
+  BuildSolution: 'Downloader.sln'
+  BuildPlatform: 'any cpu'
   BuildConfiguration: 'Release'
   RestoreBuildProjects: 'Downloader/*.csproj'
+  
 steps:
-- task: DotNetCoreCLI@2
-  displayName: Build
+- task: VSBuild@1
+  displayName: 'Build solution'
   inputs:
-    projects: '$(RestoreBuildProjects)'
-    arguments: '--configuration $(BuildConfiguration)'
+    solution: '$(BuildSolution)'
+    msbuildArgs: '/p:DeployOnBuild=true /p:DeployDefaultTarget=WebPublish /p:WebPublishMethod=FileSystem /p:DeleteExistingFiles=True /p:publishUrl="$(Agent.TempDirectory)\WebAppContent\\"'
+    platform: '$(BuildPlatform)'
+    configuration: '$(BuildConfiguration)'
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact'
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -4,7 +4,7 @@ pool:
   vmImage: 'Ubuntu 16.04'
 variables:
   BuildConfiguration: 'Release'
-  RestoreBuildProjects: '/Downloader/*.csproj'
+  RestoreBuildProjects: 'Downloader/*.csproj'
 steps:
 - task: DotNetCoreCLI@2
   displayName: Build

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,14 @@ variables:
   RestoreBuildProjects: 'Downloader/*.csproj'
   
 steps:
+- task: NuGetToolInstaller@0
+  displayName: 'Use NuGet 4.4.1'
+  inputs:
+    versionSpec: 4.4.1
+- task: NuGetCommand@2
+  displayName: 'NuGet restore'
+  inputs:
+    restoreSolution: '$(BuildSolution)'
 - task: VSBuild@1
   displayName: 'Build solution'
   inputs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,17 @@
+# ASP.NET Core build
+
+pool:
+  vmImage: 'Ubuntu 16.04'
+variables:
+  BuildConfiguration: 'Release'
+  RestoreBuildProjects: '/Downloader/*.csproj'
+steps:
+- task: DotNetCoreCLI@2
+  displayName: Build
+  inputs:
+    projects: '$(RestoreBuildProjects)'
+    arguments: '--configuration $(BuildConfiguration)'
+- task: PublishBuildArtifacts@1
+  displayName: 'Publish Artifact'
+  inputs:
+PathtoPublish: '$(build.artifactstagingdirectory)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,4 +14,4 @@ steps:
 - task: PublishBuildArtifacts@1
   displayName: 'Publish Artifact'
   inputs:
-PathtoPublish: '$(build.artifactstagingdirectory)'
+    PathtoPublish: '$(build.artifactstagingdirectory)'


### PR DESCRIPTION
Hi @paule96,

I added an AzureDevOps Pipeline definition File in this PR which will execute a Build Job and finally create an Artifact in ZIP Format. 

You just have to add a free [Microsoft Azure DevOps Tenant](https://azure.microsoft.com/en-us/blog/announcing-azure-pipelines-with-unlimited-ci-cd-minutes-for-open-source/) and link it with your repository and then you are all set. 
The definition is stored in the azure-pipelines.yml file. 

If you have any questions do not hesitate to ask. 

This PR is presented by [fixvember](https://codefresh.io/fixvember/)